### PR TITLE
ignore fragments in URL

### DIFF
--- a/background.js
+++ b/background.js
@@ -49,7 +49,9 @@ function getYoutubeURLs(url){
 }
 
 function trimURL(url){
-    return url.split('://')[1].split('?')[0];
+    return url.split('://')[1]
+        .split('#')[0]
+        .split('?')[0];
 }
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -27,5 +27,5 @@
         "http://www.reddit.com/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "0.8.114"
+    "version": "0.8.115"
 }


### PR DESCRIPTION
Reddit seems to ignore fragments in link submissions and also Forbes seems to generate a random one on every page load.