### PR TITLE
potential lscache storage fix

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,8 @@
+// Bug with lscache when Thredd is updated:
+// pre-existing cached items lose the -cacheexpiration suffix so
+// lscache doesn't know to flush them
+lscache.flush();
+
 // update on URL update
 chrome.tabs.onUpdated.addListener(function(tabId, change, tab) {
     console.log('onUpdated: ' + tabId)

--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,5 @@
         "http://www.reddit.com/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "0.8.123"
+    "version": "0.8.124"
 }


### PR DESCRIPTION
Bug with lscache when Thredd is updated:
pre-existing cached items lose the -cacheexpiration suffix so lscache doesn't know to flush them