### PR TITLE
Bugfix/403

### DIFF
--- a/background.js
+++ b/background.js
@@ -437,6 +437,22 @@ function backgroundSnoowrap() {
                     });
                 }
                 return listing_filtered;
+              })
+              .catch(error => {
+                console.error(error);
+                console.error('current time: ' + new Date().getTime().toString());
+                if (lscache.get('is_logged_in_reddit')) {
+                    console.error('using logged in requester. Expires:');
+                    console.error(lscache.get('is_logged_in_reddit-cacheexpiration'));
+                    // TODO: write a log out function
+                    lscache.set('is_logged_in_reddit', null);  // reset to use anonymous token
+                } else {
+                    console.error('using anonymous_requester');
+                    console.error(anonymous_requester);
+                    anonymous_requester = {};  // reset to get a new one next time
+                }
+                // TODO: only reset if error has status 403
+                return [];
               });
         },
 
@@ -479,7 +495,7 @@ function backgroundSnoowrap() {
                     })
                     .then(data => data.map(elem => elem.link_id))  // array of submission IDs
                     .catch(error => {
-                        console.log(error);
+                        console.error(error);
                         return [];
                     })
                 );

--- a/background.js
+++ b/background.js
@@ -443,15 +443,13 @@ function backgroundSnoowrap() {
                 console.error('current time: ' + new Date().getTime().toString());
                 if (lscache.get('is_logged_in_reddit')) {
                     console.error('using logged in requester. Expires:');
-                    console.error(lscache.get('is_logged_in_reddit-cacheexpiration'));
-                    // TODO: write a log out function
-                    lscache.set('is_logged_in_reddit', null);  // reset to use anonymous token
+                    console.error(lscache.get('is_logged_in_reddit-cacheexpiration') * 1000 * 60);  // ms
+                    // TODO: reset logged_in_reddit but only if error has status 403
                 } else {
                     console.error('using anonymous_requester');
                     console.error(anonymous_requester);
                     anonymous_requester = {};  // reset to get a new one next time
                 }
-                // TODO: only reset if error has status 403
                 return [];
               });
         },

--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,5 @@
         "http://www.reddit.com/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "0.8.125"
+    "version": "0.8.126"
 }


### PR DESCRIPTION
add a `.catch` statement to `searchSubmissionsForURL` to prevent it from creating the Loading... bug. Also resets `anonymous_requester` whenever `searchSubmissionsForURL` generates an error because it had probably expired.