### PR TITLE
getURLInfo always returns a Promise

### DIFF
--- a/background.js
+++ b/background.js
@@ -93,7 +93,9 @@ function getURLInfo(tab, override_url){
     if (posts != null) {
         console.log('getURLInfo: cached.')
         updateBadge(posts.length, tab);
-        return;
+        return new Promise(function(resolve, reject) {
+            resolve(SubmissionCollectionLscache.get(url) || []);
+        });
     } else if (tab.url.indexOf('http') == -1) {
         return new Promise(function(resolve, reject) {
             resolve([]);
@@ -776,9 +778,5 @@ chrome.runtime.onInstalled.addListener(function(details) {
     if (details.reason == 'install') {
         let install_window = window.open('http://thredd.io/thank-you/', '_blank');
         install_window.opener = null;
-    }
-    if (details.reason == 'update') {
-        let update_window = window.open('http://thredd.io/changelog/', '_blank');
-        update_window.opener = null;
     }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
         "*://*/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "web_accessible_resources": [
         "comment.html",
         "options.html",


### PR DESCRIPTION
Not sure why this only happens sometimes (depending on the computer) but local storage is supposed to be different depending on the web page and the background page (see [here](https://stackoverflow.com/questions/26412895/localstorage-different-for-webpage-and-chrome-extension)) so `popup.js` can think that there were no results in lscache while `background.js` thinks that there are. In this situation, `getURLInfo` would return `undefined` because it was assuming there would never be a mismatch in localStorage. I changed it to return a Promise with the correct data instead.