### PR TITLE
build using web-ext

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - publish:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
 
 
 version: 2
@@ -36,6 +28,7 @@ jobs:
           name: "Install Dependencies Part 2"
           command: |
             npm install -g browserify
+            npm install -g web-ext
       - restore_cache: # special step to restore the dependency cache
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: dependency-cache-{{ checksum "package.json" }}
@@ -58,33 +51,8 @@ jobs:
           name: "Run Tests"
           command: npm run test
       - run:
-          name: "git config"
-          command: |
-            git config --global user.email '$RONNY_PERSONAL_EMAIL'
-            git config --global user.name 'Ronny Li'
-      - run:
           name: "Package Extension"
           command: |
-            rm .gitignore
-            git add js/secret.js
-            git add background_browserify.js
-            git commit -m "DO NOT MERGE"
-            git archive -o thredd.zip HEAD
+            web-ext build
       - store_artifacts:
-          path: thredd.zip
-      - persist_to_workspace:
-          root: /root/project
-          paths:
-            - thredd.zip
-
-  publish:
-    docker:
-      - image: cibuilds/chrome-extension:latest
-    environment:
-      - APP_ID: "nofhlafikocbioemioehbpadpgjlpeco"
-    steps:
-      - attach_workspace:
-          at: /root/workspace
-      - run:
-          name: "Publish to the Google Chrome Store"
-          command: publish /root/workspace/thredd.zip
+          path: web-ext-artifacts/


### PR DESCRIPTION
Advantage of `web-ext` over `git archive`: web-ext will include things that are .gitignored so now there's no need to mess with the circleci build whenever a required file is gitignored