### PR TITLE
Search for page title when no links are found

### DIFF
--- a/background.js
+++ b/background.js
@@ -87,7 +87,7 @@ function getURLInfo(tab, override_url){
         })
         .then(listing => {
             if (listing.length == 0) {
-                return snoo.searchSnoowrap(`"${tab.title}"`)
+                return snoo.searchPushshift(tab.title)
             } else {
                 return listing
             }

--- a/background.js
+++ b/background.js
@@ -55,7 +55,8 @@ function changeAction(tab) {
             } else {
                 const fake_tab = {
                     url: url,
-                    id: tab.id
+                    id: tab.id,
+                    title: tab.title
                 };
                 lscache.set(DEDUPE_KEY + url + tab.id, "", 2)
                 isBlacklisted(fake_tab, disableBadge, getURLInfo)
@@ -83,6 +84,13 @@ function getURLInfo(tab, override_url){
             snoo.searchSubmissionsForURL(trimmed_url)])
         .then(values => {
             return [].concat.apply([], values);
+        })
+        .then(listing => {
+            if (listing.length == 0) {
+                return snoo.searchSnoowrap(`"${tab.title}"`)
+            } else {
+                return listing
+            }
         })
         .then(function(listing) {
             updateBadge(listing.length, tab);

--- a/js/react-components/thredd_result_details.js
+++ b/js/react-components/thredd_result_details.js
@@ -76,7 +76,7 @@ class ThreddResultDetails extends React.Component {
     renderDetails() {
         const decoded_html = this.htmlDecode(this.props.body_html);
         let comment_html;
-        if (decoded_html.indexOf('</a>') != -1) {
+        if (decoded_html.indexOf('</div>') != -1) {
             comment_html = decoded_html;
         } else {
             comment_html = this.props.body_html;

--- a/js/snoowrap_background.js
+++ b/js/snoowrap_background.js
@@ -136,6 +136,73 @@ function backgroundSnoowrap() {
           });
     }
 
+    function searchPushshift(q) {
+        const comment_api = 'https://api.pushshift.io/reddit/search/comment/?';
+        const submission_api = 'https://api.pushshift.io/reddit/search/submission/?';
+        const fields = ['author', 'body', 'created_utc', 'id', 'link_id', 'score'];
+        let comments = [];
+
+        return fetch(comment_api + 'q=' + URI.encode(q) + '&fields=' + fields.join(','))
+        .then(response => response.json())
+        .then(resp => resp.data)
+        .then(data => {
+            // get up-to-date info from Reddit
+            // TODO: remove when pushshift is synced with Reddit
+            const comment_ids = data.map(elem => 't1_' + elem.id);
+            return reddit_api.getBatchIds(comment_ids);
+        })
+        .then(data => data.map(elem => {
+            elem.body_html = elem.body_html || marked(elem.body);
+            comments.push(elem);
+            return elem.link_id;  // array of submission IDs
+        }))
+        .catch(error => {
+            console.error(error);
+            return [];
+        })
+        .then(ids => {
+            if (ids.length == 0) {
+                throw new Error('aborting pushshift api call');
+                return [];
+            } else {
+                // pushshift submission_api is not as up-to-date as Reddit's
+                // but the benefit is that there's only one API call
+                return fetch(submission_api + 'ids=' + ids.toString());
+            }
+        })
+        .then(response => response.json())
+        .then(resp => resp.data)
+        .then(listing => {
+            let listing_filtered = listing;
+            // Filter out NSFW results
+            if (true) {  // TODO: convert this to an option
+                listing_filtered = listing.filter((el) => {return !el.over_18});
+            }
+            return listing_filtered;
+        })
+        .then(listing => listing.map(function(el) {
+            el.thredd_result_type = 'comment';
+            el.thredd_result_details = comments.find(comment => {
+                const submission_id = el.id.indexOf('_') != -1 ? el.id : 't3_' + el.id;
+                return comment.link_id == submission_id;
+            });
+            if (el.subreddit_type === 'user') {
+                el.subreddit_name_prefixed = el.subreddit.replace('_', '/');
+                return el;
+            } else {
+                el.subreddit_name_prefixed = 'r/' + el.subreddit;
+                return el;
+            }
+        }))
+        .catch(error => {
+            if (error.message === 'aborting pushshift api call') {
+                return [];
+            } else {
+                throw error;
+            }
+        });
+    }
+
     return {
         setSnoowrapFromAuthCode: setSnoowrapFromAuthCode,
 
@@ -436,6 +503,8 @@ function backgroundSnoowrap() {
                 }
             });
         },
+
+        searchPushshift: searchPushshift,
 
         saveReddit: function(id, save_type, replyable_content_type, callback) {
             getSnoowrapRequester()

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
        "default_icon": { "19": "images/thredd19.png", "38": "images/thredd38.png" },
        "default_title": "Thredd"
     },
-    "description": "Learn from people while you surf the web! Find Redditors talking about their experience with the site you're on.",
+    "description": "Learn from people while you surf the web!",
     "options_page": "options.html",
     "icons": {
        "19": "images/thredd19.png",

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
        "default_icon": { "19": "images/thredd19.png", "38": "images/thredd38.png" },
        "default_title": "Thredd"
     },
-    "description": "See Reddit discussions about the page you're reading. Learn from others' experiences and get their recommendations!",
+    "description": "Learn from people while you surf the web! Find Redditors talking about their experience with the site you're on.",
     "options_page": "options.html",
     "icons": {
        "19": "images/thredd19.png",
@@ -18,7 +18,7 @@
        "64": "images/thredd64.png",
        "128": "images/thredd128.png"
     },
-    "name": "Thredd - Useful Advice on the Internet",
+    "name": "Thredd - Useful Advice from Reddit",
     "short_name": "Thredd",
     "permissions": [
         "identity",
@@ -28,7 +28,7 @@
         "*://*/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "web_accessible_resources": [
         "comment.html",
         "options.html",

--- a/tests/snoowrap_background.test.js
+++ b/tests/snoowrap_background.test.js
@@ -147,9 +147,18 @@ test('logInReddit', () => {
 //     expect(0).toBe(1);
 // });
 
+// test('searchSnoowrap', () => {
+//     expect(0).toBe(1);
+// });
+
 // test('searchCommentsForURL', () => {
 //     expect(0).toBe(1);
 // });
+
+// test('searchPushshift', () => {
+//     expect(0).toBe(1);
+// });
+
 
 // test('saveReddit', () => {
 //     expect(0).toBe(1);


### PR DESCRIPTION
Current behavior: Only search for references to the current page's URL
New behavior: If no references to the URL are found then search for the page title so comments about similar topics can still be returned.

Only search Pushshift because Reddit search isn't great (case-sensitive and poor performance with multi-word queries)