### PR TITLE
turn off link preview on reddit

### DIFF
--- a/js/page/page.js
+++ b/js/page/page.js
@@ -7,8 +7,10 @@ function pageDispatcher() {
         let url = tab.url;
         if (url.indexOf('www.google') > -1) {
             parseGoogleResults();
-        } else if (url.indexOf('duckduckgo') > -1) {
+        } else if (url.indexOf('duckduckgo.com') > -1) {
             parseDuckDuckGoResults();
+        } else if (url.indexOf('reddit.com') > -1) {
+            // do nothing because obviously the links are being discussed on Reddit
         } else {
             parseDefault();
         }

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
         "*://*/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "web_accessible_resources": [
         "comment.html",
         "options.html",


### PR DESCRIPTION
Previewing Thredd results for links shared on Reddit is pretty pointless. Turn off this annoying feature.