### PR TITLE
css bugfix for link preview logo

### DIFF
--- a/js/page/page.js
+++ b/js/page/page.js
@@ -55,10 +55,10 @@ function displayResults(href) {
                     thredd_results.title = '${listing.length} Thredd results!';
                     var thredd_logo = document.createElement('img');
                     thredd_logo.src = chrome.extension.getURL("images/thredd256.png");;
-                    thredd_logo.setAttribute('style', 'height: 1em!important; width: auto;');
+                    thredd_logo.setAttribute('style', 'display: inline; height: 1em!important; width: auto;');
                     thredd_results.appendChild(thredd_logo);
                     var thredd_num = document.createElement('strong');
-                    thredd_num.setAttribute('style', 'position: absolute; right:-0.5em; bottom:0.25em; background:rgb(236, 19, 19); text-align: center; border-radius: 0.75em 0.75em 0.75em 0.75em; color:white; padding:0.25em 0.25em; font-size:0.5em');
+                    thredd_num.setAttribute('style', 'display:inline; background:rgb(236, 19, 19); text-align: center; border-radius: 20%/40%; color:white; padding:0.25em; font-size:0.6em; margin-right: 0.5%;');
                     thredd_num.textContent = ' ${listing.length}';
                     thredd_results.appendChild(thredd_num);
                     a.forEach(elem => elem.appendChild(thredd_results));

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
         "*://*/*",
         "storage"],
     "update_url": "http://clients2.google.com/service/update2/crx",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "web_accessible_resources": [
         "comment.html",
         "options.html",


### PR DESCRIPTION
Old behavior:
![image](https://user-images.githubusercontent.com/6841011/76376069-c34c9980-631d-11ea-99fe-b878836ab5dd.png)
New behavior:
![image](https://user-images.githubusercontent.com/6841011/76376087-cf385b80-631d-11ea-8f9d-8e957ef1f5c8.png)

If a website has images set to `display:block` then it affects the thredd logo as well. This change specifies `display:inline` in order to override that setting. I also got feedback that the number of results shouldn't cover the logo. I agree that I don't need to be so stingy about space.